### PR TITLE
Add a giant example at the top of the page

### DIFF
--- a/_includes/page-layout.njk
+++ b/_includes/page-layout.njk
@@ -36,6 +36,31 @@ title: My Rad Blog
         border: none;
       }
 
+      #big-demo {
+        font-size: 3em;
+        background-color: #ddd;
+        padding: 2em;
+        height: 8em
+      }
+
+      @media screen and (max-width: 480px) {
+        #big-demo {
+          padding: 1em;
+          font-size: 1em;
+        }
+      }
+
+      #big-demo fieldset {
+        padding: 0;
+      }
+
+      #big-demo input[name="country"] {
+        box-sizing: border-box;
+        display: block;
+        margin: 0.2em 0;
+        width: 100%;
+      }
+
     </style>
     <script src="https://cdn.jsdelivr.net/npm/plete@0.2.x/dist/main.js"></script>
   </head>

--- a/index.md
+++ b/index.md
@@ -11,6 +11,48 @@ A vanilla js autocomplete component that supports remote filtering.
 
 It enhances an existing `<input type="text"/>` element and provides callbacks when busy, ready and selections are made.
 
+## Quick demo
+
+<section id="big-demo">
+  <form>
+    <fieldset>
+      <label>
+        Country<br/>
+        <input type="text" autocomplete="off" name="country" autofocus="autofocus" />
+      </label>
+    </fieldset>
+  </form>
+  <p>
+    You selected: <span class="selectedValue"></span>
+  </p>
+  <script>
+    async function filterCountries(query) {
+      const response = await fetch(`https://restcountries.eu/rest/v2/name/${query}`);
+      const result = await response.json();
+      if (!Array.isArray(result)) {
+        return [];
+      }
+      return result.map(function(v) {
+        return {
+          id: v.alpha3Code,
+          label: v.name
+        }
+      });
+    }
+    const plete4 = new Plete({
+      input: document.querySelector("#big-demo input[name='country']"),
+      dataSrc: filterCountries,
+      select: function(id) {
+        document.querySelector("#big-demo .selectedValue").textContent = id;
+      }
+    });
+  </script>
+</section>
+
+There are [more demos below](#demos)
+
+
+
 ## Features
 
 * Good WAI-ARIA support
@@ -204,7 +246,7 @@ render: function renderOption(item) {
 }
 ```
 
-## Demos
+<h2 id="demos">Demos</h2>
 
 ### String values
 


### PR DESCRIPTION
This PR adds a giant example at the top of the page.

#### Desktop

![2020-01-11 at 15 02](https://user-images.githubusercontent.com/20321/72206261-7f572880-3483-11ea-8409-7dbf2ec13bc8.png)

#### "Mobile"

![2020-01-11 at 15 04](https://user-images.githubusercontent.com/20321/72206288-a9104f80-3483-11ea-8b53-73d94c984037.png)
