### PR TITLE
Guard Fetches so that .json() should be JSON

### DIFF
--- a/_includes/examples/big-demo.html
+++ b/_includes/examples/big-demo.html
@@ -15,6 +15,9 @@
     async function filterCountries(query) {
       const url = `${window.location.origin}/.netlify/functions/countries?query=${query}`
       const response = await fetch(url);
+      if (!response.ok) {
+        return [];
+      }
       const result = await response.json();
       if (!Array.isArray(result)) {
         return [];

--- a/_includes/examples/remote-filtering.html
+++ b/_includes/examples/remote-filtering.html
@@ -14,6 +14,9 @@
     async function filterCountries(query) {
       const url = `${window.location.origin}/.netlify/functions/countries?query=${query}`
       const response = await fetch(url);
+      if (!response.ok) {
+        return [];
+      }
       const result = await response.json();
       if (!Array.isArray(result)) {
         return [];

--- a/index.md
+++ b/index.md
@@ -141,6 +141,9 @@ Using an async function as `dataSrc` allows us to do remote filtering and mappin
 ```js
 const dataSrc = async function filterCountries(query) {
   const response = await fetch(`https://restcountries.eu/rest/v2/name/${query}`);
+  if (!response.ok) {
+    return [];
+  }
   const result = await response.json();
   if (!Array.isArray(result)) {
     return [];
@@ -243,6 +246,9 @@ const dataSrc = [
 ```js
 const dataSrc = async function filterCountries(query) {
   const response = await fetch(`https://restcountries.eu/rest/v2/name/${query}`);
+  if (!response.ok) {
+    return [];
+  }
   const result = await response.json();
   if (!Array.isArray(result)) {
     return [];


### PR DESCRIPTION
Looking into #7 seeing "Will this work on mac?" I found it did not, but not for entirely obvious reasons.

> `${window.location.origin}/.netlify/functions/countries?query=${query}`

was part of it. That resolves nowhere for me. I assume this is about CORS or other remote foreign domains?

But then I noticed this was calling `.json()` without first checking the response was ok.

Probably speaks to needing some form of errorResponse method so that the `return [];` doesn't bleed all over the place, but for now, I think a nice guard.